### PR TITLE
FIX: Unavailable files (due to a CN bug) are no longer created

### DIFF
--- a/CampusNetDrop.py
+++ b/CampusNetDrop.py
@@ -1,5 +1,6 @@
 import os, datetime, getpass, requests
 import xml.etree.ElementTree as ET
+import json
 
 def sendRequest(url):
 	dirname, filename = os.path.split(os.path.abspath(__file__))
@@ -60,6 +61,13 @@ def download_file(elementID,downloadID,file_path):
 	url='https://www.campusnet.dtu.dk/data/CurrentUser/Elements/%s/Files/%s/Bytes' % (str(elementID),str(downloadID))
 	response = sendRequest(url)
 	data = response.content
+	
+	if 'application/json' in str(response.headers['Content-Type']):
+		json_data = json.loads(data)
+		if 'Message' in json_data and "error" in str(json_data['Message']):
+			print("File " + file_path + " turned out to be unavailable. Skipped.")
+			return
+
 	with open(file_path, 'wb') as f:
 		f.write(data)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This is a tiny application to synchronize the shared files of your courses, proj
 
 Download or clone the application files into a directory.
 
+Install `requests` package if you don't have it available:
+
+```pip3 install requests```
+
 Run the configuration:
 
 ```python /pathToDirectory/configuration.py```


### PR DESCRIPTION
Turns out Campusnet returns an index of all files - including the ones not yet available for download. Because of that, an error JSON response was written to the target location instead of the actual file. 

This introduces a check of the response ensuring that the requested file is downloaded correctly. 